### PR TITLE
Use column names instead of star in select all (workaround JAVA-420)

### DIFF
--- a/src/test/java/com/datastax/driver/mapping/MappingSessionTest.java
+++ b/src/test/java/com/datastax/driver/mapping/MappingSessionTest.java
@@ -1017,4 +1017,21 @@ public class MappingSessionTest {
         obj.setKey(new TimeUUIDKey());
         target.save(obj);
     }
+
+    @Test
+    public void whenAnFieldAddedToTable_thenPreparedSelectShouldReturnTheField() throws Exception {
+        // setup
+        UUID userId = UUID.randomUUID();
+        UserWithAge user = new UserWithAge(userId, "user1", 100);
+        assertNotNull(target.save(user));
+        target.doNotSync = true;
+
+        // call sut
+        target.get(UserWithoutAge.class, userId);
+        UserWithAge withAge = target.get(UserWithAge.class, userId);
+
+        // check results
+        assertEquals(100, withAge.getAge());
+        assertEquals(userId, withAge.getId());
+    }
 }

--- a/src/test/java/com/datastax/driver/mapping/entity/UserWithAge.java
+++ b/src/test/java/com/datastax/driver/mapping/entity/UserWithAge.java
@@ -1,0 +1,48 @@
+package com.datastax.driver.mapping.entity;
+
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.UUID;
+
+@Table(name="table_user")
+public class UserWithAge {
+
+    @Id
+    private UUID id;
+    private String name;
+    private int age;
+
+    public UserWithAge() {
+        // do nothing
+    }
+
+    public UserWithAge(UUID userId, String name, int age) {
+        this.id = userId;
+        this.name = name;
+        this.age = age;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/src/test/java/com/datastax/driver/mapping/entity/UserWithoutAge.java
+++ b/src/test/java/com/datastax/driver/mapping/entity/UserWithoutAge.java
@@ -1,0 +1,29 @@
+package com.datastax.driver.mapping.entity;
+
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.UUID;
+
+@Table(name="table_user")
+public class UserWithoutAge {
+
+    @Id
+    private UUID id;
+    private String name;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
I've added workaround for https://datastax-oss.atlassian.net/browse/JAVA-420

There protected method buildSelectAll exists in MappingBuilder:
protected static Select buildSelectAll(String table, List<String> pkCols, ReadOptions options, String keyspace)

I didn't know reasons why it's protected so I kept it untouched.